### PR TITLE
Implement local timezone support

### DIFF
--- a/VERSION_1.1.1_RELEASE_NOTES.md
+++ b/VERSION_1.1.1_RELEASE_NOTES.md
@@ -1,0 +1,16 @@
+# Offer Tracker v1.1.1 Release Notes
+## Local Timezone Update
+
+**Release Date**: June 5, 2024
+**Version**: 1.1.1
+
+---
+
+### Features
+- Offers and follow-ups now record dates in your local timezone
+
+### Improvements
+- Today filters and reminders respect your computer's time settings
+
+### Fixes
+- Resolved issue where late-night offers were counted for the next day

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "offer-tracker",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "main": "electron/main.cjs",
   "scripts": {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -8,6 +8,7 @@ import { toast } from "@/hooks/use-toast";
 import { DashboardItemsManager } from "./dashboard/DashboardItemsManager";
 import { DashboardHeader } from "./dashboard/DashboardHeader";
 import { useSimpleKeyboardShortcuts } from "@/hooks/use-simple-keyboard-shortcuts";
+import { getTodayDateString } from "@/utils/dateUtils";
 import { HelpButton } from "./HelpButton";
 import { useToast } from "@/components/ui/use-toast";
 import { useNavigate } from "react-router-dom";
@@ -73,7 +74,7 @@ export function Dashboard() {
       });
     }
     
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayDateString();
     
     // Check both followups array and legacy followupDate
     const urgentFollowups = offers.filter(o => {

--- a/src/components/FollowupItem.tsx
+++ b/src/components/FollowupItem.tsx
@@ -4,6 +4,7 @@ import { CalendarClock, CheckCircle, AlertTriangle, PlusCircle } from "lucide-re
 import { format } from "date-fns";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Offer, FollowupItem as FollowupItemType } from "@/context/OfferContext";
+import { getTodayDateString } from "@/utils/dateUtils";
 import { CaseLink } from "./CaseLink";
 import { Badge } from "@/components/ui/badge";
 
@@ -26,7 +27,7 @@ export function FollowupItem({
   isOverdue,
   onAddNewFollowup
 }: FollowupItemProps) {
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayDateString();
   
   // If we don't have a followup, try to use the legacy format
   const followupDate = followup?.date || offer.followupDate || '';

--- a/src/components/FollowupList.tsx
+++ b/src/components/FollowupList.tsx
@@ -11,7 +11,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { toast } from "@/hooks/use-toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { FollowupItem } from "./FollowupItem";
-import { formatFollowupDate } from "@/utils/dateUtils";
+import { formatFollowupDate, getTodayDateString, toISODateString, toLocalISOString } from "@/utils/dateUtils";
 import { CaseLink } from "./CaseLink";
 import { useFollowupManager } from "@/hooks/useFollowupManager";
 import { Calendar } from "@/components/ui/calendar";
@@ -41,7 +41,7 @@ export function FollowupList({ onOfferClick }: FollowupListProps) {
   } = useFollowupManager();
   
   const [isOpen, setIsOpen] = useState(false);
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayDateString();
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
   const [selectedOfferId, setSelectedOfferId] = useState<string | null>(null);
   const [isAddingFollowup, setIsAddingFollowup] = useState(false);
@@ -110,7 +110,7 @@ export function FollowupList({ onOfferClick }: FollowupListProps) {
     if (selectedOfferId && selectedDate) {
       const offer = offers.find(o => o.id === selectedOfferId);
       if (offer) {
-        const dateString = selectedDate.toISOString().split('T')[0];
+        const dateString = toISODateString(selectedDate);
         await addNewFollowup(selectedOfferId, offer, dateString);
         
         // Reset state
@@ -357,7 +357,7 @@ export function FollowupList({ onOfferClick }: FollowupListProps) {
                             id: 'completed',
                             date: offer.followupDate || '',
                             completed: true,
-                            completedAt: new Date().toISOString()
+                            completedAt: toLocalISOString(new Date())
                           };
                           
                           return (

--- a/src/components/OfferDetails.tsx
+++ b/src/components/OfferDetails.tsx
@@ -18,6 +18,7 @@ import { format, differenceInDays } from "date-fns";
 import { toast } from "@/hooks/use-toast";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Calendar } from "@/components/ui/calendar";
+import { getTodayDateString, toISODateString } from "@/utils/dateUtils";
 import { Input } from "@/components/ui/input";
 import { CaseLink } from "./CaseLink";
 import { Switch } from "@/components/ui/switch";
@@ -150,7 +151,7 @@ export function OfferDetails({ offer, onClose, onUpdate }: OfferDetailsProps) {
       setEditedOffer(prev => ({ 
         ...prev, 
         converted: true,
-        conversionDate: new Date().toISOString().split('T')[0]
+        conversionDate: getTodayDateString()
       }));
     } else {
       setIsConversionCalendarOpen(false);
@@ -167,7 +168,7 @@ export function OfferDetails({ offer, onClose, onUpdate }: OfferDetailsProps) {
     if (date) {
       setEditedOffer(prev => ({ 
         ...prev,
-        conversionDate: date.toISOString().split('T')[0],
+        conversionDate: toISODateString(date),
         converted: true
       }));
       
@@ -703,7 +704,7 @@ export function OfferDetails({ offer, onClose, onUpdate }: OfferDetailsProps) {
                         setEditedOffer(prev => ({ 
                           ...prev, 
                           converted: true,
-                          conversionDate: new Date().toISOString().split('T')[0]
+                          conversionDate: getTodayDateString()
                         }));
                       } else {
                         setIsConversionCalendarOpen(false);

--- a/src/components/OfferItem.tsx
+++ b/src/components/OfferItem.tsx
@@ -13,7 +13,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Calendar as CalendarComponent } from "@/components/ui/calendar";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { CaseLink } from "./CaseLink";
-import { getConversionLagInfo } from "@/utils/dateUtils";
+import { getConversionLagInfo, getTodayDateString, toISODateString } from "@/utils/dateUtils";
 import { useFollowupManager } from "@/hooks/useFollowupManager";
 import { useNavigate } from "react-router-dom";
 
@@ -86,9 +86,9 @@ export const OfferItem = React.memo(({ offer, onUpdate, className = "" }: OfferI
   const handleConversionChange = (converted: boolean) => {
     if (converted) {
       setShowConversionDate(true);
-      updateOffer(offer.id, { 
-        converted, 
-        conversionDate: new Date().toISOString().split('T')[0]
+      updateOffer(offer.id, {
+        converted,
+        conversionDate: getTodayDateString()
       });
     } else {
       setShowConversionDate(false);
@@ -107,7 +107,7 @@ export const OfferItem = React.memo(({ offer, onUpdate, className = "" }: OfferI
 
   const handleConversionDateChange = (date: Date | undefined) => {
     if (date) {
-      updateOffer(offer.id, { conversionDate: date.toISOString().split('T')[0] });
+      updateOffer(offer.id, { conversionDate: toISODateString(date) });
       onUpdate?.();
       toast({
         title: "Conversion Date Updated",
@@ -119,7 +119,7 @@ export const OfferItem = React.memo(({ offer, onUpdate, className = "" }: OfferI
   const handleFollowupDateChange = (date: Date | undefined) => {
     if (date) {
       // If setting a new followup date
-      const dateString = date.toISOString().split('T')[0];
+      const dateString = toISODateString(date);
       
       // Create a new followup item
       const newFollowup = {
@@ -271,7 +271,7 @@ export const OfferItem = React.memo(({ offer, onUpdate, className = "" }: OfferI
     
     try {
       // Get today's date in YYYY-MM-DD format
-      const today = new Date().toISOString().split('T')[0];
+      const today = getTodayDateString();
       
       // Add a new followup for today
       const success = await addNewFollowup(
@@ -331,7 +331,7 @@ export const OfferItem = React.memo(({ offer, onUpdate, className = "" }: OfferI
     // Don't show due date for converted offers
     if (offer.converted) return null;
 
-    const today = new Date().toISOString().split("T")[0];
+    const today = getTodayDateString();
     const dueDate = new Date();
     dueDate.setDate(date.getDate() + 30);
     const formattedDueDate = format(dueDate, "MMM d");
@@ -567,9 +567,9 @@ export const OfferItem = React.memo(({ offer, onUpdate, className = "" }: OfferI
                         return;
                       }
 
-                      updateOffer(offer.id, { 
+                      updateOffer(offer.id, {
                         converted: true,
-                        conversionDate: date.toISOString().split('T')[0] 
+                        conversionDate: toISODateString(date)
                       });
                       toast({
                         title: "Offer Converted",

--- a/src/components/OfferList.tsx
+++ b/src/components/OfferList.tsx
@@ -24,6 +24,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { exportToCsv } from "@/utils/exportData";
+import { getTodayDateString, toISODateString } from "@/utils/dateUtils";
 import { toast } from "@/hooks/use-toast";
 import { Separator } from "@/components/ui/separator";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -188,8 +189,8 @@ export function OfferList({
       if (selectedType) newSearchParams.set("type", selectedType);
       if (selectedCSAT) newSearchParams.set("csat", selectedCSAT);
       if (selectedConversion) newSearchParams.set("converted", selectedConversion);
-      if (startDate) newSearchParams.set("startDate", startDate.toISOString().split('T')[0]);
-      if (endDate) newSearchParams.set("endDate", endDate.toISOString().split('T')[0]);
+      if (startDate) newSearchParams.set("startDate", toISODateString(startDate));
+      if (endDate) newSearchParams.set("endDate", toISODateString(endDate));
       
       setSearchParams(newSearchParams);
     }
@@ -207,7 +208,7 @@ export function OfferList({
     let filteredResults = offers;
     
     if (mode === 'today') {
-      const today = new Date().toISOString().split('T')[0];
+      const today = getTodayDateString();
       filteredResults = offers.filter(offer => offer.date.startsWith(today));
     }
     

--- a/src/components/RecentOffersList.tsx
+++ b/src/components/RecentOffersList.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
+import { getTodayDateString, toISODateString } from "@/utils/dateUtils";
 import { toast } from "@/hooks/use-toast";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -56,7 +57,7 @@ export function RecentOffersList({ offers, onOfferClick, hideFilters = false }: 
     if (converted) {
       updateOffer(offerId, { 
         converted: true,
-        conversionDate: new Date().toISOString().split('T')[0]
+        conversionDate: getTodayDateString()
       });
       toast({
         title: "Conversion Status Updated",
@@ -78,7 +79,7 @@ export function RecentOffersList({ offers, onOfferClick, hideFilters = false }: 
     if (date) {
       updateOffer(offerId, { 
         converted: true,
-        conversionDate: date.toISOString().split('T')[0]
+        conversionDate: toISODateString(date)
       });
       toast({
         title: "Offer Converted",
@@ -96,7 +97,7 @@ export function RecentOffersList({ offers, onOfferClick, hideFilters = false }: 
       date.setMinutes(minutes);
       
       // Convert date to YYYY-MM-DD format
-      const dateString = date.toISOString().split('T')[0];
+      const dateString = toISODateString(date);
 
       // Get the current offer to update
       const offer = offers.find(o => o.id === offerId);

--- a/src/components/offer-form/ConversionDateField.tsx
+++ b/src/components/offer-form/ConversionDateField.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
+import { getTodayDateString, toISODateString } from "@/utils/dateUtils";
 import { Switch } from "@/components/ui/switch";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CalendarIcon, ShoppingCart, X } from "lucide-react";
@@ -29,7 +30,7 @@ export function ConversionDateField({ form }: ConversionDateFieldProps) {
     setIsConverted(checked);
     if (checked) {
       // Set today's date as default
-      const today = new Date().toISOString().split('T')[0];
+      const today = getTodayDateString();
       form.setValue('conversionDate', today);
       toast({
         title: "Marked as Converted",
@@ -47,7 +48,7 @@ export function ConversionDateField({ form }: ConversionDateFieldProps) {
 
   const handleDateSelect = (date: Date | undefined) => {
     if (date) {
-      form.setValue('conversionDate', date.toISOString().split('T')[0]);
+      form.setValue('conversionDate', toISODateString(date));
       toast({
         title: "Conversion Date Set",
         description: `Conversion date set to ${format(date, "PPP")}`,

--- a/src/components/performance-studio/MonthlyGoalSummary.tsx
+++ b/src/components/performance-studio/MonthlyGoalSummary.tsx
@@ -19,7 +19,7 @@ import {
   Star
 } from "lucide-react";
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isToday, subMonths, getDay, addDays } from 'date-fns';
-import { getDaysInMonth, getDaysPassedInCurrentMonth } from '@/utils/dateUtils';
+import { getDaysInMonth, getDaysPassedInCurrentMonth, toISODateString } from '@/utils/dateUtils';
 import { Slider } from "@/components/ui/slider";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -153,15 +153,15 @@ export const MonthlyGoalSummary = () => {
   // Get the date range for the current month
   const startOfCurrentMonth = startOfMonth(currentDate);
   const endOfCurrentMonth = endOfMonth(currentDate);
-  const startOfMonthStr = startOfCurrentMonth.toISOString().split('T')[0];
-  const currentDateStr = currentDate.toISOString().split('T')[0];
+  const startOfMonthStr = toISODateString(startOfCurrentMonth);
+  const currentDateStr = toISODateString(currentDate);
   
   // Previous month data
   const prevMonth = subMonths(currentDate, 1);
   const startOfPrevMonth = startOfMonth(prevMonth);
   const endOfPrevMonth = endOfMonth(prevMonth);
-  const startOfPrevMonthStr = startOfPrevMonth.toISOString().split('T')[0];
-  const endOfPrevMonthStr = endOfPrevMonth.toISOString().split('T')[0];
+  const startOfPrevMonthStr = toISODateString(startOfPrevMonth);
+  const endOfPrevMonthStr = toISODateString(endOfPrevMonth);
   
   // Filter offers for current month
   const offersThisMonth = offers.filter(offer => {

--- a/src/components/performance-studio/TrendsBreakdown.tsx
+++ b/src/components/performance-studio/TrendsBreakdown.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/utils/trendAnalysis";
 import { motion } from "framer-motion";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { formatDateForStorage } from "@/utils/dateUtils";
+import { formatDateForStorage, toISODateString } from "@/utils/dateUtils";
 import { ModernAnalyticsCard } from "@/components/charts/ModernAnalyticsCard";
 import { TrendsLineChart } from "@/components/charts/TrendsLineChart";
 import { TrendsBarChart } from "@/components/charts/TrendsBarChart";
@@ -106,7 +106,7 @@ export const TrendsBreakdown: React.FC = () => {
     
     // Group by date
     sortedOffers.forEach(offer => {
-      const dateKey = new Date(offer.date).toISOString().split('T')[0];
+      const dateKey = toISODateString(new Date(offer.date));
       if (!dateMap.has(dateKey)) {
         dateMap.set(dateKey, { 
           date: dateKey, 

--- a/src/context/OfferContext.tsx
+++ b/src/context/OfferContext.tsx
@@ -6,6 +6,7 @@ import { parseISO, isWithinInterval, startOfDay, endOfDay, differenceInDays } fr
 import { format } from 'date-fns';
 import { calculateEnhancedStreak, StreakInfo } from '@/utils/streakCalculation';
 import { generateUUID } from '@/utils/uuid';
+import { getTodayDateString, toLocalISOString } from '@/utils/dateUtils';
 
 export interface Offer {
   id: string;
@@ -140,12 +141,12 @@ export const OfferProvider: React.FC<OfferProviderProps> = ({ children }) => {
   }, [offers, isLoading]);
 
   const todaysOffers = useMemo(() => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayDateString();
     return offers.filter(offer => offer.date.startsWith(today));
   }, [offers]);
 
   const checkFollowups = useCallback(() => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayDateString();
     
     offers.forEach(offer => {
       // Check active followups in the new structure
@@ -213,7 +214,7 @@ export const OfferProvider: React.FC<OfferProviderProps> = ({ children }) => {
     const newOffer: Offer = {
       ...offer,
       id: generateUUID(),
-      date: offer.dateOverride || new Date().toISOString(),
+      date: offer.dateOverride || toLocalISOString(new Date()),
     };
     
     setOffers(prev => [newOffer, ...prev]);
@@ -235,7 +236,7 @@ export const OfferProvider: React.FC<OfferProviderProps> = ({ children }) => {
             if (offer.id === id) {
               // Handle conversion date logic
               if (updatesCopy.converted === true && !updatesCopy.conversionDate && !offer.conversionDate) {
-                updatesCopy.conversionDate = new Date().toISOString().split('T')[0];
+                updatesCopy.conversionDate = getTodayDateString();
               }
               
               if (updatesCopy.converted === false) {

--- a/src/hooks/useFollowupManager.ts
+++ b/src/hooks/useFollowupManager.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 import { v4 as uuidv4 } from 'uuid';
 import { Offer, FollowupItem, useOffers } from '@/context/OfferContext';
 import { generateUUID } from '@/utils/uuid';
+import { getTodayDateString, toLocalISOString } from '@/utils/dateUtils';
 
 export function useFollowupManager() {
   const { updateOffer, offers } = useOffers();
@@ -36,7 +37,7 @@ export function useFollowupManager() {
           updatedFollowups[followupIndex] = {
             ...updatedFollowups[followupIndex],
             completed: true,
-            completedAt: new Date().toISOString()
+            completedAt: toLocalISOString(new Date())
           };
         } else {
           console.warn(`Followup with ID ${followupId} not found`);
@@ -62,7 +63,7 @@ export function useFollowupManager() {
             updatedFollowups[followupIndex] = {
               ...updatedFollowups[followupIndex],
               completed: true,
-              completedAt: new Date().toISOString()
+              completedAt: toLocalISOString(new Date())
             };
           }
         } else {
@@ -75,7 +76,7 @@ export function useFollowupManager() {
           id: generateUUID(),
           date: offer.followupDate,
           completed: true,
-          completedAt: new Date().toISOString(),
+          completedAt: toLocalISOString(new Date()),
           notes: 'Automatically migrated from legacy format'
         });
       } else {
@@ -194,7 +195,7 @@ export function useFollowupManager() {
           return {
             ...followup,
             completed: true,
-            completedAt: new Date().toISOString(),
+            completedAt: toLocalISOString(new Date()),
             notes: followup.notes ? `${followup.notes} (Canceled)` : 'Canceled'
           };
         }
@@ -261,7 +262,7 @@ export function useFollowupManager() {
     const followupDate = getActiveFollowupDate(offer);
     if (!followupDate) return false;
     
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayDateString();
     return followupDate === today;
   }, [getActiveFollowupDate]);
 
@@ -269,7 +270,7 @@ export function useFollowupManager() {
     const followupDate = getActiveFollowupDate(offer);
     if (!followupDate) return false;
     
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayDateString();
     return followupDate < today;
   }, [getActiveFollowupDate]);
 
@@ -336,7 +337,7 @@ export function useFollowupManager() {
 
   // Categorize followups into today, overdue, and upcoming
   const getCategorizedFollowups = useCallback(() => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayDateString();
     const overdue: Offer[] = [];
     const todayFollowups: Offer[] = [];
     const upcoming: Offer[] = [];

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-const CURRENT_VERSION = '1.1.0'; // This should match package.json version
+const CURRENT_VERSION = '1.1.1'; // This should match package.json version
 const VERSION_STORAGE_KEY = 'offer-tracker-last-seen-version';
 
 export interface UpdateInfo {
@@ -13,6 +13,19 @@ export interface UpdateInfo {
 
 // Define what's new for each version
 const VERSION_UPDATES: Record<string, UpdateInfo> = {
+  '1.1.1': {
+    version: '1.1.1',
+    title: 'Local Timezone Update',
+    features: [
+      'Offers and follow-ups now record dates using your local timezone'
+    ],
+    improvements: [
+      'Today filters and reminders match your computer\'s time'
+    ],
+    fixes: [
+      'Fixed late-night offers counting toward the next day'
+    ]
+  },
   '1.1.0': {
     version: '1.1.0',
     title: 'Smart Follow-ups & Update System',

--- a/src/pages/Offers.tsx
+++ b/src/pages/Offers.tsx
@@ -9,6 +9,7 @@ import { PlusCircle, Clock, Filter, Search, Download, X, RefreshCw } from "lucid
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useSearchParams } from "react-router-dom";
 import { useUser } from "@/context/UserContext";
+import { getTodayDateString, toISODateString } from "@/utils/dateUtils";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { 
@@ -144,8 +145,8 @@ const Offers = () => {
     if (selectedType) newParams.set("type", selectedType);
     if (selectedCSAT) newParams.set("csat", selectedCSAT);
     if (selectedConversion) newParams.set("converted", selectedConversion);
-    if (startDate) newParams.set("startDate", startDate.toISOString().split('T')[0]);
-    if (endDate) newParams.set("endDate", endDate.toISOString().split('T')[0]);
+    if (startDate) newParams.set("startDate", toISODateString(startDate));
+    if (endDate) newParams.set("endDate", toISODateString(endDate));
     
     // Only update if they've changed to avoid unnecessary history entries
     if (newParams.toString() !== searchParams.toString()) {
@@ -362,7 +363,7 @@ const Offers = () => {
     if (converted) {
       updateOffer(offerId, { 
         converted: true,
-        conversionDate: new Date().toISOString().split('T')[0]
+        conversionDate: getTodayDateString()
       });
       toast({
         title: "Conversion Status Updated",
@@ -384,7 +385,7 @@ const Offers = () => {
     if (date) {
       updateOffer(offerId, { 
         converted: true,
-        conversionDate: date.toISOString().split('T')[0]
+        conversionDate: toISODateString(date)
       });
       toast({
         title: "Offer Converted",
@@ -397,7 +398,7 @@ const Offers = () => {
   const handleFollowupDateChange = (offerId: string, date: Date | undefined) => {
     if (!date) return;
     
-    const dateString = date.toISOString().split('T')[0];
+    const dateString = toISODateString(date);
     const offer = offers.find(o => o.id === offerId);
     if (!offer) return;
     
@@ -439,7 +440,7 @@ const Offers = () => {
     
     try {
       // Get today's date in YYYY-MM-DD format
-      const today = new Date().toISOString().split('T')[0];
+      const today = getTodayDateString();
       
       // Add a new followup for today
       const success = await addNewFollowup(

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -38,7 +38,7 @@ export const formatFollowupDate = (date: Date | string): string => {
  * Formats a date for storing as a follow-up date (YYYY-MM-DD)
  */
 export const formatDateForStorage = (date: Date): string => {
-  return date.toISOString().split('T')[0];
+  return toISODateString(date);
 };
 
 /**
@@ -73,7 +73,13 @@ export function getConversionLagInfo(offerDate: string, conversionDate: string |
  * Returns today's date as YYYY-MM-DD
  */
 export const getTodayDateString = (): string => {
-  return new Date().toISOString().split('T')[0];
+  return toISODateString(new Date());
+};
+
+export const toLocalISOString = (date: Date): string => {
+  const offsetMs = date.getTimezoneOffset() * 60000;
+  const localDate = new Date(date.getTime() - offsetMs);
+  return localDate.toISOString().replace('Z', '');
 };
 
 /**

--- a/src/utils/offerFilters.ts
+++ b/src/utils/offerFilters.ts
@@ -1,5 +1,6 @@
 import { Offer } from "@/context/OfferContext";
 import { parseISO, isWithinInterval, startOfDay, endOfDay, isSameDay } from "date-fns";
+import { getTodayDateString } from './dateUtils';
 
 // Helper function to check if an offer has active followups
 const hasActiveFollowup = (offer: Offer): boolean => {
@@ -34,7 +35,7 @@ export const isFollowupOverdue = (offer: Offer): boolean => {
   const activeFollowupDate = getActiveFollowupDate(offer);
   if (!activeFollowupDate) return false;
   
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayDateString();
   return activeFollowupDate < today;
 };
 
@@ -43,7 +44,7 @@ export const isFollowupDueToday = (offer: Offer): boolean => {
   const activeFollowupDate = getActiveFollowupDate(offer);
   if (!activeFollowupDate) return false;
   
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayDateString();
   return activeFollowupDate === today;
 };
 


### PR DESCRIPTION
## Summary
- record offers using the computer's local timezone
- handle today's date with a helper and update followup checks
- add local time utilities
- bump version to 1.1.1 with release notes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841e961708c832191c5fcc0c44d8ec6